### PR TITLE
Add dependency on 'debops.secret'

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
 
 galaxy_info:
   author: 'Maciej Delmanowski'


### PR DESCRIPTION
It's useful to have ssh keys in a protected location, and without
'debops.secret' dependency Ansible stops processing the role if lookups
in secret/ directory are set in inventory.